### PR TITLE
Add Metrics resource with adjustment methods

### DIFF
--- a/lib/kickplan/adapters/http.rb
+++ b/lib/kickplan/adapters/http.rb
@@ -25,6 +25,12 @@ module Kickplan
         post("features", params.to_h).body
       end
 
+      def update_metric(params)
+        path = ["metrics", params.key, params.action].join("/")
+
+        post(path, params.to_h.slice(:value, :context)).body
+      end
+
       # @api private
       def connection
         memoize do

--- a/lib/kickplan/adapters/memory.rb
+++ b/lib/kickplan/adapters/memory.rb
@@ -38,6 +38,23 @@ module Kickplan
         end
       end
 
+      def update_metric(params)
+        lookup_key = [params.key, params.context.account_key].join(".")
+        current_value = metrics[lookup_key] || 0
+
+        new_value =
+          case params.action
+          when "set"
+            params.value
+          when "increment"
+            current_value + params.value
+          when "decrement"
+            current_value - params.value
+          end
+
+        metrics[lookup_key] = new_value
+      end
+
       # @api private
       def accounts
         memoize { Concurrent::Map.new }
@@ -45,6 +62,11 @@ module Kickplan
 
       # @api private
       def features
+        memoize { Concurrent::Map.new }
+      end
+
+      # @api private
+      def metrics
         memoize { Concurrent::Map.new }
       end
 

--- a/lib/kickplan/request.rb
+++ b/lib/kickplan/request.rb
@@ -13,4 +13,5 @@ module Kickplan
   require_relative "requests/configure_account"
   require_relative "requests/configure_feature"
   require_relative "requests/resolve_feature"
+  require_relative "requests/update_metric"
 end

--- a/lib/kickplan/requests/update_metric.rb
+++ b/lib/kickplan/requests/update_metric.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module Kickplan
+  module Requests
+    class UpdateMetric < Request
+      attribute :action, Types::String.enum("decrement", "increment", "set")
+      attribute :key, Types::String
+      attribute :value, Types::Any
+
+      attribute :context do
+        attribute :account_key, Types::String
+      end
+    end
+  end
+end

--- a/lib/kickplan/resource.rb
+++ b/lib/kickplan/resource.rb
@@ -19,4 +19,5 @@ module Kickplan
 
   require_relative "resources/accounts"
   require_relative "resources/features"
+  require_relative "resources/metrics"
 end

--- a/lib/kickplan/resources/metrics.rb
+++ b/lib/kickplan/resources/metrics.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+module Kickplan
+  module Resources
+    class Metrics < Resource
+      def decrement(key, value, context = nil)
+        update("decrement", key, value, context)
+      end
+
+      def increment(key, value, context = nil)
+        update("increment", key, value, context)
+      end
+
+      def set(key, value, context = nil)
+        update("set", key, value, context)
+      end
+
+      def update(action, key, value, context = nil)
+        if value.is_a?(Hash) && context.nil?
+          value, context = 1, value
+        end
+
+        params = Requests::UpdateMetric.new(
+          action: action,
+          context: context,
+          key: key,
+          value: value
+        )
+
+        adapter.update_metric(params)
+        true
+      end
+    end
+  end
+end

--- a/spec/cassettes/metrics/decrement.yml
+++ b/spec/cassettes/metrics/decrement.yml
@@ -1,0 +1,41 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://example.com/api/metrics/seats_used/decrement
+    body:
+      encoding: UTF-8
+      string: '{"value":3,"context":{"account_key":"a6a9cd9a-77af-4c1a-bc8d-4339eb00a081"}}'
+    headers:
+      User-Agent:
+      - Kickplan SDK v0.1.0
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Date:
+      - Mon, 30 Oct 2023 18:53:24 GMT
+      Server:
+      - Fly/7328d5b5 (2023-10-27)
+      X-Request-Id:
+      - F5L3YMrMmnvDm0UAAAOR
+      Via:
+      - 1.1 fly.io
+      Fly-Request-Id:
+      - 01HE0YXYPHWBEZEFT521MGQDYS-sea
+      Content-Length:
+      - '0'
+    body:
+      encoding: UTF-8
+      string: ''
+  recorded_at: Mon, 30 Oct 2023 18:53:24 GMT
+recorded_with: VCR 6.2.0

--- a/spec/cassettes/metrics/increment.yml
+++ b/spec/cassettes/metrics/increment.yml
@@ -1,0 +1,41 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://example.com/api/metrics/seats_used/increment
+    body:
+      encoding: UTF-8
+      string: '{"value":3,"context":{"account_key":"a6a9cd9a-77af-4c1a-bc8d-4339eb00a081"}}'
+    headers:
+      User-Agent:
+      - Kickplan SDK v0.1.0
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Date:
+      - Mon, 30 Oct 2023 18:54:54 GMT
+      Server:
+      - Fly/7328d5b5 (2023-10-27)
+      X-Request-Id:
+      - F5L3de-AEwrAg0cAAAPh
+      Via:
+      - 1.1 fly.io
+      Fly-Request-Id:
+      - 01HE0Z0QCB2VHZZP323PYVCMKZ-sea
+      Content-Length:
+      - '0'
+    body:
+      encoding: UTF-8
+      string: ''
+  recorded_at: Mon, 30 Oct 2023 18:54:55 GMT
+recorded_with: VCR 6.2.0

--- a/spec/cassettes/metrics/set.yml
+++ b/spec/cassettes/metrics/set.yml
@@ -1,0 +1,41 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://example.com/api/metrics/seats_used/set
+    body:
+      encoding: UTF-8
+      string: '{"value":3,"context":{"account_key":"a6a9cd9a-77af-4c1a-bc8d-4339eb00a081"}}'
+    headers:
+      User-Agent:
+      - Kickplan SDK v0.1.0
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Date:
+      - Mon, 30 Oct 2023 18:54:54 GMT
+      Server:
+      - Fly/7328d5b5 (2023-10-27)
+      X-Request-Id:
+      - F5L3de1GBiXO81MAAAQh
+      Via:
+      - 1.1 fly.io
+      Fly-Request-Id:
+      - 01HE0Z0QB4MCVEXBKKZWC2QFET-sea
+      Content-Length:
+      - '0'
+    body:
+      encoding: UTF-8
+      string: ''
+  recorded_at: Mon, 30 Oct 2023 18:54:55 GMT
+recorded_with: VCR 6.2.0

--- a/spec/cassettes/resolve/feature.yml
+++ b/spec/cassettes/resolve/feature.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: post
-    uri: "https://example.com/features/digital-merch-products"
+    uri: "https://example.com/api/features/digital-merch-products"
     body:
       encoding: UTF-8
       string: '{"context":{"account_id":"a6a9cd9a-77af-4c1a-bc8d-4339eb00a081"}}'

--- a/spec/cassettes/resolve/features-detailed.yml
+++ b/spec/cassettes/resolve/features-detailed.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: post
-    uri: "https://example.com/features"
+    uri: "https://example.com/api/features"
     body:
       encoding: UTF-8
       string: '{"context":{"account_id":"a6a9cd9a-77af-4c1a-bc8d-4339eb00a081"},"detailed":true}'

--- a/spec/cassettes/resolve/features.yml
+++ b/spec/cassettes/resolve/features.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: post
-    uri: "https://example.com/features"
+    uri: "https://example.com/api/features"
     body:
       encoding: UTF-8
       string: '{"context":{"account_id":"a6a9cd9a-77af-4c1a-bc8d-4339eb00a081"}}'

--- a/spec/kickplan/adapters/http_spec.rb
+++ b/spec/kickplan/adapters/http_spec.rb
@@ -12,6 +12,7 @@ RSpec.describe Kickplan::Adapters::HTTP do
 
   # Test the adapter through the resource interface
   let(:accounts) { client::Accounts }
+  let(:metrics) { client::Metrics }
   let(:features) { client::Features }
 
   subject(:adapter) { client.adapter }
@@ -61,6 +62,46 @@ RSpec.describe Kickplan::Adapters::HTTP do
 
       expect(response).to be_a Array
       expect(response).to all be_a Kickplan::Responses::Resolution
+    end
+  end
+
+  describe "#update_metric" do
+    let(:key) { "seats_used" }
+    let(:value) { 3 }
+    let(:context) {{ account_key: "a6a9cd9a-77af-4c1a-bc8d-4339eb00a081" }}
+    let(:params) {{ value: value, context: context }}
+
+    context "when performing a `decrement` on the metric",
+      vcr: { cassette_name: "metrics/decrement" } do
+      it "creates a POST request for 'metrics/:key/decrement'" do
+        expect(adapter.connection).to receive(:post).
+          with("metrics/#{key}/decrement", params).
+          and_call_original
+
+        metrics.decrement(key, value, context)
+      end
+    end
+
+    context "when performing a `increment` on the metric",
+      vcr: { cassette_name: "metrics/increment" } do
+      it "creates a POST request for 'metrics/:key/increment'" do
+        expect(adapter.connection).to receive(:post).
+          with("metrics/#{key}/increment", params).
+          and_call_original
+
+        metrics.increment(key, value, context)
+      end
+    end
+
+    context "when performing a `set` on the metric",
+      vcr: { cassette_name: "metrics/set" } do
+      it "creates a POST request for 'metrics/:key/set'" do
+        expect(adapter.connection).to receive(:post).
+          with("metrics/#{key}/set", params).
+          and_call_original
+
+        metrics.set(key, value, context)
+      end
     end
   end
 end

--- a/spec/kickplan/adapters/http_spec.rb
+++ b/spec/kickplan/adapters/http_spec.rb
@@ -5,7 +5,7 @@ require "spec_helper"
 RSpec.describe Kickplan::Adapters::HTTP do
   Kickplan[:http].configure do |config|
     config.adapter = :http
-    config.endpoint = ENV.fetch("KICKPLAN_ENDPOINT", "https://example.com/")
+    config.endpoint = ENV.fetch("KICKPLAN_ENDPOINT", "https://example.com/api")
   end
 
   let(:client) { Kickplan.client(:http) }

--- a/spec/kickplan/adapters/memory_spec.rb
+++ b/spec/kickplan/adapters/memory_spec.rb
@@ -12,6 +12,7 @@ RSpec.describe Kickplan::Adapters::Memory do
   # Test the adapter through the resource interface
   let(:accounts) { client::Accounts }
   let(:features) { client::Features }
+  let(:metrics)  { client::Metrics }
 
   subject(:adapter) { client.adapter }
 
@@ -121,6 +122,53 @@ RSpec.describe Kickplan::Adapters::Memory do
       expect(resolution).to all be_a Kickplan::Responses::Resolution
       expect(resolution.size).to eq 2
       expect(resolution.map(&:key)).to match_array(["chat", "seats"])
+    end
+  end
+
+  describe "#update_metric" do
+    let(:store) { adapter.metrics }
+
+    let(:key) { "seats_used" }
+    let(:account_key) { "a6a9cd9a-77af-4c1a-bc8d-4339eb00a081" }
+    let(:store_key) { [key, account_key].join(".") }
+
+    context "when performing a `decrement` on the metric" do
+      it "decrements the value in the metrics store", :aggregate_failures do
+        expect(store).to be_empty
+
+        metrics.decrement(key, account_key: account_key)
+        expect(store).to_not be_empty
+        expect(store[store_key]).to eq -1
+
+        metrics.decrement(key, 3, account_key: account_key)
+        expect(store[store_key]).to eq -4
+      end
+    end
+
+    context "when performing a `increment` on the metric" do
+      it "increments the value in the metrics store", :aggregate_failures do
+        expect(store).to be_empty
+
+        metrics.increment(key, account_key: account_key)
+        expect(store).to_not be_empty
+        expect(store[store_key]).to eq 1
+
+        metrics.increment(key, 3, account_key: account_key)
+        expect(store[store_key]).to eq 4
+      end
+    end
+
+    context "when performing a `set` on the metric" do
+      it "sets the value in the metrics store", :aggregate_failures do
+        expect(store).to be_empty
+
+        metrics.set(key, account_key: account_key)
+        expect(store).to_not be_empty
+        expect(store[store_key]).to eq 1
+
+        metrics.set(key, 3, account_key: account_key)
+        expect(store[store_key]).to eq 3
+      end
     end
   end
 end


### PR DESCRIPTION
The functions will be used for setting the value of a metric directly.

It supports three actions: `decrement`, `increment`, and `set`. If a value is not supplied, it is assumed to be `1`.

The usage looks like:

```ruby
Kickplan::Metrics.set("seats_used", 3, account_key: "...")
Kickplan::Metrics.increment("seats_used", 2, account_key: "...")
Kickplan::Metrics.decrement("seats_used", 1, account_key: "...")

# => The metric value would now be 4
```