### PR TITLE
docs: Update docs with newest resource endpoints

### DIFF
--- a/lib/kickplan.rb
+++ b/lib/kickplan.rb
@@ -20,7 +20,7 @@ module Kickplan
 
   class << self
     def client(name = :default)
-      clients.fetch_or_store(name) { Client.new }
+      clients.fetch_or_store(name.to_s) { Client.new(name) }
     end
     alias_method :[], :client
 

--- a/lib/kickplan/client.rb
+++ b/lib/kickplan/client.rb
@@ -10,7 +10,11 @@ module Kickplan
     include Concurrency
     include Configuration
 
-    def initialize
+    attr_reader :name
+
+    def initialize(name)
+      @name = name.to_s
+
       # Use global configuration as client defaults
       config.update(Kickplan.config.values)
     end
@@ -18,6 +22,11 @@ module Kickplan
     def adapter
       memoize { Adapter.for(config) }
     end
+
+    def inspect
+      "#<#{self.class.name}(#{name})>"
+    end
+    alias_method :to_s, :inspect
 
     def reset
       unset(:adapter)

--- a/lib/kickplan/resource.rb
+++ b/lib/kickplan/resource.rb
@@ -15,6 +15,11 @@ module Kickplan
     def initialize(client)
       @client = client
     end
+
+    def inspect
+      "#{client.inspect}::#{self.class.name.split("::").last}"
+    end
+    alias_method :to_s, :inspect
   end
 
   require_relative "resources/accounts"


### PR DESCRIPTION
Also updated the `#inspect` methods for `Client` and `Resource` to make it clearer which client you're dealing with.