### PR TITLE
fix: Const lookup shouldn't leave the namespace

### DIFF
--- a/lib/kickplan.rb
+++ b/lib/kickplan.rb
@@ -31,7 +31,7 @@ module Kickplan
     private
 
     def const_missing(name)
-      client.const_get(name)
+      client.const_get(name, false)
     end
   end
 end

--- a/lib/kickplan/client.rb
+++ b/lib/kickplan/client.rb
@@ -1,5 +1,8 @@
 # frozen_string_literal: true
 
+module Features
+end
+
 module Kickplan
   require_relative "adapters"
   require_relative "concurrency"
@@ -36,7 +39,7 @@ module Kickplan
 
     def const_missing(name)
       synchronize do
-        Resources.const_get(name).new(self).tap do |resource|
+        Resources.const_get(name, false).new(self).tap do |resource|
           self.const_set(name, resource)
         end
       end


### PR DESCRIPTION
Setting the `inherit` flag for `#const_get` to false so we don't try to find constants outside the `Kickplan` namespace.