### PR TITLE
feat: Add `time` to `Metrics::Set` request

### DIFF
--- a/lib/kickplan/requests/metrics/set.rb
+++ b/lib/kickplan/requests/metrics/set.rb
@@ -7,7 +7,7 @@ module Kickplan
         attribute :key, Types::String
         attribute :value, Types::Any
         attribute :account_key, Types::String
-        attribute :time, Types::DateTime
+        attribute? :time, Types::DateTime
       end
     end
   end

--- a/lib/kickplan/requests/metrics/set.rb
+++ b/lib/kickplan/requests/metrics/set.rb
@@ -7,6 +7,7 @@ module Kickplan
         attribute :key, Types::String
         attribute :value, Types::Any
         attribute :account_key, Types::String
+        attribute :time, Types::DateTime
       end
     end
   end

--- a/spec/cassettes/metrics/set.yml
+++ b/spec/cassettes/metrics/set.yml
@@ -5,7 +5,7 @@ http_interactions:
     uri: https://example.com/api/metrics/set
     body:
       encoding: UTF-8
-      string: '{"key":"seats_used","value":3,"account_key":"9a592f57-6da0-408e-99e7-8918b48a7dbe"}'
+      string: '{"key":"seats_used","value":3,"account_key":"9a592f57-6da0-408e-99e7-8918b48a7dbe","time":"2024-03-22T13:44:32-07:00"}'
     headers:
       User-Agent:
       - Kickplan SDK v0.1.0
@@ -23,19 +23,19 @@ http_interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Date:
-      - Fri, 08 Mar 2024 00:09:24 GMT
+      - Fri, 22 Mar 2024 20:44:32 GMT
       Server:
-      - Fly/089de441 (2024-03-05)
+      - Fly/0052f39f (2024-03-18)
       X-Request-Id:
-      - F7qhfIGzTSLbftwAAAEx
+      - F78xAyzwC5GbEPAAAAfB
       Via:
       - 1.1 fly.io
       Fly-Request-Id:
-      - 01HRDP99DMD74F15JAHH7EB2VQ-sea
+      - 01HSKYGYZ88KB11CEPG7FWM508-sea
       Content-Length:
       - '0'
     body:
       encoding: UTF-8
       string: ''
-  recorded_at: Fri, 08 Mar 2024 00:09:24 GMT
+  recorded_at: Fri, 22 Mar 2024 20:44:33 GMT
 recorded_with: VCR 6.2.0

--- a/spec/kickplan/adapters/http_spec.rb
+++ b/spec/kickplan/adapters/http_spec.rb
@@ -99,7 +99,8 @@ RSpec.describe Kickplan::Adapters::HTTP do
     let(:params) {{
       key: "seats_used",
       value: 3,
-      account_key: "9a592f57-6da0-408e-99e7-8918b48a7dbe"
+      account_key: "9a592f57-6da0-408e-99e7-8918b48a7dbe",
+      time: DateTime.now()
     }}
 
     it "creates a POST request for 'metrics/set'" do


### PR DESCRIPTION
This allows the `time` field to be set to an arbitrary time and not just default to `now()`.