### PR TITLE
fix: Isolate client configurations

### DIFF
--- a/docs/Overview.md
+++ b/docs/Overview.md
@@ -190,23 +190,22 @@ Kickplan[:default]::Features
 
 ### Configuration
 
-The Kickplan SDK can be configured globally or on a per-client level. By default,
-all clients will utilize the global configuration but you can also configure the client
-directly:
+Each Kickplan client has it own isolated configuration. This does mean that each will need
+to be configured individually.
 
 ```ruby
-# Global configuration
+# Default client config
 Kickplan.configure do |config|
   config.access_token = "1234"
 end
 
-Kickplan.client.config.access_token
+Kickplan.config.access_token
 => "1234"
 
 Kickplan[:custom].config.access_token
-=> "1234"
+=> nil
 
-# Client configuration
+# Custom client config
 Kickplan[:custom].configure do |config|
   config.access_token = "4321"
 end

--- a/lib/kickplan.rb
+++ b/lib/kickplan.rb
@@ -11,14 +11,15 @@ require "forwardable"
 
 module Kickplan
   require_relative "kickplan/client"
-  require_relative "kickplan/configuration"
   require_relative "kickplan/version"
-
-  extend Configuration
 
   @_clients = Concurrent::Map.new
 
   class << self
+    extend Forwardable
+
+    delegate [:config, :configure] => :client
+
     def client(name = :default)
       clients.fetch_or_store(name.to_s) { Client.new(name) }
     end

--- a/lib/kickplan/client.rb
+++ b/lib/kickplan/client.rb
@@ -14,9 +14,6 @@ module Kickplan
 
     def initialize(name)
       @name = name.to_s
-
-      # Use global configuration as client defaults
-      config.update(Kickplan.config.values)
     end
 
     def adapter

--- a/spec/kickplan_spec.rb
+++ b/spec/kickplan_spec.rb
@@ -7,6 +7,10 @@ RSpec.describe Kickplan do
     expect(Kickplan.client).to be Kickplan.client(:default)
   end
 
+  it "has a default config" do
+    expect(Kickplan.config).to be Kickplan[:default].config
+  end
+
   it "has default resources" do
     expect(Kickplan::Features).to be Kickplan[:default]::Features
   end


### PR DESCRIPTION
This removes the "global" configuration, which has two effects:

  1. `Kickplan.config` now delegates to the default client. Previously, any changes done to `Kickplan.config` __after__ the default client was instantiated would not be reflected on that client's config which was unexpected and confusing.

  2. Defaults are not shared to new clients. This means every client needs to be configured individually, even if they share duplicate values. I may address this for non-default clients in the future if a need arises.