### PR TITLE
feat: Utilize `access_token` in http adapter

### DIFF
--- a/lib/kickplan/adapters/http.rb
+++ b/lib/kickplan/adapters/http.rb
@@ -51,6 +51,7 @@ module Kickplan
             proxy: config.proxy,
             builder: config.middleware,
             headers: {
+              authorization: "Bearer #{config.access_token}",
               user_agent: config.user_agent
             }
           )

--- a/spec/cassettes/accounts/create.yml
+++ b/spec/cassettes/accounts/create.yml
@@ -7,6 +7,8 @@ http_interactions:
       encoding: UTF-8
       string: '{"key":"acme","name":"Acme Inc.","custom_fields":{"salesforce-id":"1234"},"account_plans":[{"plan_key":"small"}],"feature_overrides":[{"override":"variant_key","feature_key":"metrics","variant_key":"true"}]}'
     headers:
+      Authorization:
+      - Bearer <KICKPLAN_ACCESS_TOKEN>
       User-Agent:
       - Kickplan SDK v0.1.0
       Content-Type:
@@ -25,20 +27,20 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 22 Feb 2024 20:07:44 GMT
+      - Fri, 20 Sep 2024 21:15:12 GMT
       Server:
-      - Fly/17d0263d (2024-02-15)
+      - Fly/0c45e4378 (2024-09-20)
       X-Request-Id:
-      - F7ZILIXqDgx0RaAAAAFx
+      - F_cQTpk8G2KbVvQAAAjR
       Transfer-Encoding:
       - chunked
       Via:
       - 1.1 fly.io
       Fly-Request-Id:
-      - 01HQ96WQ9KFJ02N8N7SQ6NA787-sea
+      - 01J88MKWMANXGW1D92Z1105K9Y-sea
     body:
       encoding: ASCII-8BIT
-      string: '{"feature_overrides":["metrics/true"],"inserted_at":"2024-02-22T20:07:44.706979Z","key":"acme","name":"Acme
-        Inc.","plans":["small"],"updated_at":"2024-02-22T20:07:44.706979Z"}'
-  recorded_at: Thu, 22 Feb 2024 20:07:44 GMT
+      string: '{"feature_overrides":["metrics/true"],"inserted_at":"2024-09-20T21:15:11.922049Z","key":"acme","name":"Acme
+        Inc.","plans":[],"updated_at":"2024-09-20T21:15:11.922049Z"}'
+  recorded_at: Fri, 20 Sep 2024 21:15:12 GMT
 recorded_with: VCR 6.2.0

--- a/spec/cassettes/accounts/update.yml
+++ b/spec/cassettes/accounts/update.yml
@@ -7,6 +7,8 @@ http_interactions:
       encoding: UTF-8
       string: '{"name":"Acme Inc.","custom_fields":{"salesforce-id":"4321"},"account_plans":[{"plan_key":"large"}],"feature_overrides":[{"override":"variant_key","feature_key":"metrics","variant_key":"false"}]}'
     headers:
+      Authorization:
+      - Bearer <KICKPLAN_ACCESS_TOKEN>
       User-Agent:
       - Kickplan SDK v0.1.0
       Content-Type:
@@ -25,20 +27,20 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 22 Feb 2024 20:13:06 GMT
+      - Fri, 20 Sep 2024 21:15:12 GMT
       Server:
-      - Fly/17d0263d (2024-02-15)
+      - Fly/0c45e4378 (2024-09-20)
       X-Request-Id:
-      - F7ZId48CSOea9CUAAAGB
+      - F_cQTsF2QRqFeoEAAAkB
       Transfer-Encoding:
       - chunked
       Via:
       - 1.1 fly.io
       Fly-Request-Id:
-      - 01HQ976J0QMZMXMS6DMNZ9KETD-sea
+      - 01J88MKX9DGNZGJHJNTVYHGG6B-sea
     body:
       encoding: ASCII-8BIT
-      string: '{"feature_overrides":["metrics/false"],"inserted_at":"2024-02-22T20:07:44.706979Z","key":"acme","name":"Acme
-        Inc.","plans":["large"],"updated_at":"2024-02-22T20:13:06.995778Z"}'
-  recorded_at: Thu, 22 Feb 2024 20:13:07 GMT
+      string: '{"feature_overrides":["metrics/false"],"inserted_at":"2024-09-20T21:15:11.922049Z","key":"acme","name":"Acme
+        Inc.","plans":[],"updated_at":"2024-09-20T21:15:12.603703Z"}'
+  recorded_at: Fri, 20 Sep 2024 21:15:12 GMT
 recorded_with: VCR 6.2.0

--- a/spec/cassettes/features/resolve-all.yml
+++ b/spec/cassettes/features/resolve-all.yml
@@ -7,6 +7,8 @@ http_interactions:
       encoding: UTF-8
       string: '{"detailed":false,"context":{"account_key":"9a592f57-6da0-408e-99e7-8918b48a7dbe"}}'
     headers:
+      Authorization:
+      - Bearer <KICKPLAN_ACCESS_TOKEN>
       User-Agent:
       - Kickplan SDK v0.1.0
       Content-Type:
@@ -25,20 +27,21 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 04 Jan 2024 20:07:25 GMT
+      - Fri, 20 Sep 2024 21:15:12 GMT
       Server:
-      - Fly/ec8196c09 (2024-01-02)
+      - Fly/0c45e4378 (2024-09-20)
       X-Request-Id:
-      - F6c9uDzdF1g4IT8AAAEx
+      - F_cQTrwXO5IA6AoAAAjh
       Transfer-Encoding:
       - chunked
       Via:
       - 1.1 fly.io
       Fly-Request-Id:
-      - 01HKB1CXHAHE3EHV9R5X5MFWNQ-sea
+      - 01J88MKX6KY929AYXAPEKA44QD-sea
     body:
       encoding: ASCII-8BIT
-      string: '[{"key":"features","value":true},{"key":"override","value":"Overrides
-        Off"},{"key":"metrics","value":true},{"key":"seats","value":99999},{"key":"plan","value":false}]'
-  recorded_at: Thu, 04 Jan 2024 20:07:25 GMT
+      string: '[{"value":false,"key":"upload-contacts"},{"value":false,"key":"ai-llm-generation"},{"value":false,"key":"fancy"},{"value":"{\n    \"Currency\":
+        \"US Dollar (USD)\",\n    \"Allowed Payment Gateways\": [\"PayPal\", \"Stripe\",
+        \"Square\"]\n  }","key":"payment-configuration"},{"value":0,"key":"contact-limit"}]'
+  recorded_at: Fri, 20 Sep 2024 21:15:12 GMT
 recorded_with: VCR 6.2.0

--- a/spec/cassettes/features/resolve.yml
+++ b/spec/cassettes/features/resolve.yml
@@ -2,11 +2,13 @@
 http_interactions:
 - request:
     method: post
-    uri: https://example.com/api/features/seats/resolve
+    uri: https://example.com/api/features/contact-limit/resolve
     body:
       encoding: UTF-8
-      string: '{"detailed":false,"context":{"account_key":"9a592f57-6da0-408e-99e7-8918b48a7dbe"}}'
+      string: '{"detailed":false,"context":{"account_key":"acme"}}'
     headers:
+      Authorization:
+      - Bearer <KICKPLAN_ACCESS_TOKEN>
       User-Agent:
       - Kickplan SDK v0.1.0
       Content-Type:
@@ -25,19 +27,19 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 04 Jan 2024 20:07:46 GMT
+      - Fri, 20 Sep 2024 21:17:29 GMT
       Server:
-      - Fly/ec8196c09 (2024-01-02)
+      - Fly/0c45e4378 (2024-09-20)
       X-Request-Id:
-      - F6c9vSXlvixFvmoAAAFB
+      - F_cQbs4xwjVHF64AAAkx
       Transfer-Encoding:
       - chunked
       Via:
       - 1.1 fly.io
       Fly-Request-Id:
-      - 01HKB1DJ4CVJ7RW9AZX8MGWHVY-sea
+      - 01J88MR3Q273SJJ4P68HFSBFP2-sea
     body:
       encoding: ASCII-8BIT
-      string: '{"key":"seats","value":99999}'
-  recorded_at: Thu, 04 Jan 2024 20:07:46 GMT
+      string: '{"value":0,"key":"contact-limit"}'
+  recorded_at: Fri, 20 Sep 2024 21:17:29 GMT
 recorded_with: VCR 6.2.0

--- a/spec/cassettes/metrics/flush.yml
+++ b/spec/cassettes/metrics/flush.yml
@@ -7,6 +7,8 @@ http_interactions:
       encoding: UTF-8
       string: ''
     headers:
+      Authorization:
+      - Bearer <KICKPLAN_ACCESS_TOKEN>
       User-Agent:
       - Kickplan SDK v0.1.0
       Content-Length:
@@ -23,19 +25,19 @@ http_interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Date:
-      - Fri, 09 Aug 2024 18:34:47 GMT
+      - Fri, 20 Sep 2024 21:15:12 GMT
       Server:
-      - Fly/9fe23f3e1 (2024-07-31)
+      - Fly/0c45e4378 (2024-09-20)
       X-Request-Id:
-      - F-ojLekHrWSMArsAAAbh
+      - F_cQTr5peB3Mn6cAAAjx
       Via:
       - 1.1 fly.io
       Fly-Request-Id:
-      - 01J4W6QZTQJ40RAVY680K1H78S-sea
+      - 01J88MKX7TAQV2Q0CY8V3F6K48-sea
       Content-Length:
       - '0'
     body:
       encoding: UTF-8
       string: ''
-  recorded_at: Fri, 09 Aug 2024 18:34:47 GMT
+  recorded_at: Fri, 20 Sep 2024 21:15:12 GMT
 recorded_with: VCR 6.2.0

--- a/spec/cassettes/metrics/set.yml
+++ b/spec/cassettes/metrics/set.yml
@@ -5,8 +5,10 @@ http_interactions:
     uri: https://example.com/api/metrics/set
     body:
       encoding: UTF-8
-      string: '{"key":"seats_used","value":3,"account_key":"9a592f57-6da0-408e-99e7-8918b48a7dbe","idempotency_key":"sdk-ruby-test","time":"2024-04-29T12:20:34-07:00"}'
+      string: '{"key":"seats_used","value":3,"account_key":"9a592f57-6da0-408e-99e7-8918b48a7dbe","idempotency_key":"sdk-ruby-test","time":"2024-09-20T14:15:11-07:00"}'
     headers:
+      Authorization:
+      - Bearer <KICKPLAN_ACCESS_TOKEN>
       User-Agent:
       - Kickplan SDK v0.1.0
       Content-Type:
@@ -23,19 +25,19 @@ http_interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Date:
-      - Mon, 29 Apr 2024 19:20:34 GMT
+      - Fri, 20 Sep 2024 21:15:11 GMT
       Server:
-      - Fly/a7fb3290 (2024-04-29)
+      - Fly/0c45e4378 (2024-09-20)
       X-Request-Id:
-      - F8rWe5bhYVQbs9oAABch
+      - F_cQTpbXBoHFm00AAAjB
       Via:
       - 1.1 fly.io
       Fly-Request-Id:
-      - 01HWNMTGCZ5PX9XXTPTQ970QA5-sea
+      - 01J88MKWK2CE3M9F02F87YJ33J-sea
       Content-Length:
       - '0'
     body:
       encoding: UTF-8
       string: ''
-  recorded_at: Mon, 29 Apr 2024 19:20:34 GMT
+  recorded_at: Fri, 20 Sep 2024 21:15:11 GMT
 recorded_with: VCR 6.2.0

--- a/spec/kickplan/adapters/http_spec.rb
+++ b/spec/kickplan/adapters/http_spec.rb
@@ -5,7 +5,6 @@ require "spec_helper"
 RSpec.describe Kickplan::Adapters::HTTP do
   Kickplan[:http].configure do |config|
     config.adapter = :http
-    config.endpoint = ENV.fetch("KICKPLAN_ENDPOINT", "https://example.com/api")
   end
 
   let(:client) { Kickplan.client(:http) }
@@ -58,11 +57,9 @@ RSpec.describe Kickplan::Adapters::HTTP do
   end
 
   describe "#resolve_feature", vcr: { cassette_name: "features/resolve" } do
-    let(:key) { "seats" }
+    let(:key) { "contact-limit" }
     let(:params) {{
-      context: {
-        account_key: "9a592f57-6da0-408e-99e7-8918b48a7dbe"
-      }
+      context: { account_key: "acme" }
     }}
 
     it "creates a POST request for 'features/:key'" do
@@ -84,9 +81,7 @@ RSpec.describe Kickplan::Adapters::HTTP do
 
   describe "#resolve_features", vcr: { cassette_name: "features/resolve-all" } do
     let(:params) {{
-      context: {
-        account_key: "9a592f57-6da0-408e-99e7-8918b48a7dbe"
-      }
+      context: { account_key: "acme" }
     }}
 
     it "creates a POST request for 'features'" do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -28,6 +28,8 @@ VCR.configure do |c|
   c.hook_into :faraday, :webmock
   c.configure_rspec_metadata!
 
+  c.filter_sensitive_data("<KICKPLAN_ACCESS_TOKEN>") { ENV["KICKPLAN_ACCESS_TOKEN"] }
+
   c.before_http_request do |request|
     uri = URI(request.uri)
     uri.scheme = "https"


### PR DESCRIPTION
This was previously omitted as authentication had not yet been built out in the service api.

Re-recorded cassettes to include the new (scrubbed) authorization header.